### PR TITLE
fix(release-notes-preview): allow to specify semantic version

### DIFF
--- a/release-notes-preview/README.md
+++ b/release-notes-preview/README.md
@@ -34,10 +34,11 @@ jobs:
 
 ## Inputs
 
-| parameter     | description                                                                                                           | required | default |
-| ------------- | --------------------------------------------------------------------------------------------------------------------- | -------- | ------- |
-| extra-plugins | Extra plugins for pre-install. You can also specify specifying version range for the extra plugins if you prefer.     | `false`  |         |
-| github-token  | GitHub token that can checkout the repository as well as create tags/releases against it. e.g. 'secrets.GITHUB_TOKEN' | `true`   |         |
+| parameter        | description                                                                                                           | required | default |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------- | -------- | ------- |
+| extra-plugins    | Extra plugins for pre-install. You can also specify specifying version range for the extra plugins if you prefer.     | `false`  |         |
+| github-token     | GitHub token that can checkout the repository as well as create tags/releases against it. e.g. 'secrets.GITHUB_TOKEN' | `true`   |         |
+| semantic-version | Specify what version of semantic release to use                                                                       | `false`  |         |
 
 ## Outputs
 

--- a/release-notes-preview/action.yaml
+++ b/release-notes-preview/action.yaml
@@ -14,6 +14,9 @@ inputs:
   extra-plugins:
     required: false
     description: Extra plugins for pre-install. You can also specify specifying version range for the extra plugins if you prefer.
+  semantic-version:
+    required: false
+    description: Specify what version of semantic release to use
 runs:
   using: composite
   steps:
@@ -38,6 +41,7 @@ runs:
         ci: false
         dry_run: true
         extra_plugins: ${{ inputs.extra-plugins }}
+        semantic_version: ${{ inputs.semantic-version }}
     - name: Check for release notes comment
       uses: peter-evans/find-comment@v2
       id: fc


### PR DESCRIPTION

**Description**

By default v3 of the action uses v19, which is not compatible with our node.js projects

**Changes**

* fix(release-notes-preview): allow to specify semantic version

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
