### PR TITLE
fix(release): default extra-plugins to open-turo/semantic-release-config

### DIFF
--- a/release-notes-preview/README.md
+++ b/release-notes-preview/README.md
@@ -28,17 +28,15 @@ jobs:
       - uses: open-turo/actions-release/release-notes-preview@v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          extra-plugins: |
-            @open-turo/semantic-release-config
 ```
 
 ## Inputs
 
-| parameter        | description                                                                                                           | required | default |
-| ---------------- | --------------------------------------------------------------------------------------------------------------------- | -------- | ------- |
-| extra-plugins    | Extra plugins for pre-install. You can also specify specifying version range for the extra plugins if you prefer.     | `false`  |         |
-| github-token     | GitHub token that can checkout the repository as well as create tags/releases against it. e.g. 'secrets.GITHUB_TOKEN' | `true`   |         |
-| semantic-version | Specify what version of semantic release to use                                                                       | `false`  |         |
+| parameter        | description                                                                                                                                                               | required | default                                   |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ----------------------------------------- |
+| extra-plugins    | Extra plugins for pre-install. You can also specify specifying version range for the extra plugins if you prefer. Defaults to install @open-turo/semantic-release-config. | `false`  | @open-turo/semantic-release-config@^1.4.0 |
+| github-token     | GitHub token that can checkout the repository as well as create tags/releases against it. e.g. 'secrets.GITHUB_TOKEN'                                                     | `true`   |                                           |
+| semantic-version | Specify what version of semantic release to use                                                                                                                           | `false`  |                                           |
 
 ## Outputs
 

--- a/release-notes-preview/action.yaml
+++ b/release-notes-preview/action.yaml
@@ -7,7 +7,9 @@ inputs:
     default: ${{ github.token }}
   extra-plugins:
     required: false
-    description: Extra plugins for pre-install. You can also specify specifying version range for the extra plugins if you prefer.
+    description: Extra plugins for pre-install. You can also specify specifying version range for the extra plugins if you prefer.  Defaults to install @open-turo/semantic-release-config.
+    default: |
+      @open-turo/semantic-release-config@^1.4.0
   semantic-version:
     required: false
     description: Specify what version of semantic release to use


### PR DESCRIPTION
This updates the extra-plugins to default to `@open-turo/semantic-release-config@^1.4.0`.  This will allow us to stop needing to configure it everywhere.