### PR TITLE
feat(breaking-changes): add document template

### DIFF
--- a/templates/breaking-changes.md
+++ b/templates/breaking-changes.md
@@ -1,0 +1,11 @@
+# Upgrade from v**CURRENT**.x to v**NEXT**.x
+
+[//]: # "Brief description of current major version release scope"
+
+## Description of changes
+
+[//]: # "Elaborate and add context to help the developer understand the changes."
+
+## Upgrade instructions
+
+[//]: # "Required and suggested prerequisites, example code, etc."


### PR DESCRIPTION

**Description**

Adds a document template we could use to provide a starting point for breaking changes documentation.
This template will later be used in a action when requiring documentation related to a breaking change release.

**Changes**

* feat(breaking-changes): add document template

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
