### PR TITLE
ci: use latest open-turo release config

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,14 +18,14 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: open-turo/actions-gha/lint@v1
+      - uses: open-turo/actions-gha/lint@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
   test:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: open-turo/actions-gha/test@v1
+      - uses: open-turo/actions-gha/test@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Test release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,4 +30,4 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           extra-plugins: |
-            @open-turo/semantic-release-config@^1.4.0
+            @open-turo/semantic-release-config

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,14 +9,14 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: open-turo/actions-gha/lint@v1
+      - uses: open-turo/actions-gha/lint@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
   test:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: open-turo/actions-gha/test@v1
+      - uses: open-turo/actions-gha/test@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
   release:
@@ -26,7 +26,7 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     steps:
-      - uses: open-turo/actions-gha/release@v1
+      - uses: open-turo/actions-gha/release@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           extra-plugins: |


### PR DESCRIPTION

**Description**

Now releases should work since we are now using our action for releases that works with Node 18.

**Changes**

* ci: use latest open-turo release config

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
