### PR TITLE
fix(release): don't checkout repo

### DIFF
--- a/semantic-release/README.md
+++ b/semantic-release/README.md
@@ -25,6 +25,8 @@ jobs:
   semantic-release:
     name: Release
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
       - uses: open-turo/actions-release/semantic-release@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/semantic-release/action.yaml
+++ b/semantic-release/action.yaml
@@ -47,10 +47,6 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-        persist-credentials: false
     - name: Setup tools
       uses: actions/setup-node@v3
       with:


### PR DESCRIPTION

**Description**

This should be done externally so the consumer decides how to checkout the repo (if using persist-credentials or things like that)


**Changes**

* fix(release): don't checkout repo

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
