### PR TITLE
feat: adds lint-release-notes action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: ./release-notes-preview
+      - uses: ./lint-release-notes
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
   lint:

--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ GitHub Actions for handling releases.
 
 ## Actions
 
-### action: [`release-notes-preview`](./release-notes-preview)
+### action: [`release-notes-preview`](./lint-release-notes)
 
 Automatically generate release notes using semantic-release and post them as a comment in a pull request with the changes that would be included in the next version of the codebase if the pull request is merged.
 
-See usage [here](./release-notes-preview/README.md#usage).
+See usage [here](lint-release-notes/README.md#usage).
 
-Documentation is found [here](./release-notes-preview/README.md).
+Documentation is found [here](lint-release-notes/README.md).
 
 ## Get Help
 

--- a/lint-release-notes/README.md
+++ b/lint-release-notes/README.md
@@ -1,0 +1,57 @@
+# GitHub Action Lint Release Notes
+
+## Description
+
+Github action that lints release notes. It generates release notes using semantic-release and posts them as a comment in
+a pull request with the changes that would be included in the next version of the codebase if the pull request is
+merged. It also will fail if there are breaking changes and no `v<major-version>.md` doc has been created.
+
+## Configuration
+
+### Step1: Set any [Semantic Release Configuration](https://github.com/semantic-release/semantic-release/blob/master/docs/usage/configuration.md#configuration) in your repository.
+
+### Step2: [Add Secrets](https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets) in your repository for the [Semantic Release Authentication](https://github.com/semantic-release/semantic-release/blob/master/docs/usage/ci-configuration.md#authentication) Environment Variables.
+
+### Step3: Add a [Workflow File](https://help.github.com/en/articles/workflow-syntax-for-github-actions) to your repository to create custom automated processes.
+
+## Usage
+
+```yaml
+name: Release notes preview
+
+on:
+  # It's import that this runs on the push event, as semantic release will not run on pull_request events
+  push:
+    branches-ignore:
+      - main
+
+jobs:
+  lint-release-notes:
+    name: Lint release notes
+    steps:
+      - uses: open-turo/actions-release/lint-release-notes@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+## Inputs
+
+| parameter                     | description                                                                                                                                                               | required | default                                   |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ----------------------------------------- |
+| checkout-repo                 | Perform checkout as first step of action                                                                                                                                  | `false`  | true                                      |
+| enforce-breaking-changes-docs | Ensure that an appropriate `v<major-version>.md` doc has been created if there are breaking changes in the PR. Fail if required and missing.                              | `false`  | `true`                                    |
+| extra-plugins                 | Extra plugins for pre-install. You can also specify specifying version range for the extra plugins if you prefer. Defaults to install @open-turo/semantic-release-config. | `false`  | @open-turo/semantic-release-config@^1.4.0 |
+| github-token                  | GitHub token that can checkout the repository as well as create tags/releases against it. e.g. 'secrets.GITHUB_TOKEN'                                                     | `true`   |                                           |
+| semantic-version              | Specify what version of semantic release to use                                                                                                                           | `false`  |                                           |
+
+## Outputs
+
+N/A
+
+## Runs
+
+This action is an `composite` action.
+
+## Notes
+
+- By default, this action will perform actions/checkout as its first step.

--- a/lint-release-notes/action.yaml
+++ b/lint-release-notes/action.yaml
@@ -1,13 +1,17 @@
 name: GitHub Action Release Notes Preview
 description: GitHub Action that publishes a new release.
 inputs:
+  checkout-repo:
+    required: false
+    description: Perform checkout as first step of action
+    default: "true"
   github-token:
     required: true
     description: GitHub token that can checkout the repository as well as create tags/releases against it. e.g. 'secrets.GITHUB_TOKEN'
     default: ${{ github.token }}
   enforce-breaking-changes-docs:
     required: false
-    description: Ensure that an appropriate `v<major-version>.md` doc has been created if there are breaking changes in the PR. Fail if required and missing.
+    description: Ensure that an appropriate `v<major-version>.md` doc has been created if there are breaking changes in the PR.
     default: "true"
   extra-plugins:
     required: false
@@ -20,10 +24,8 @@ inputs:
 runs:
   using: composite
   steps:
-    - shell: bash
-      run: |
-        echo "::error::DEPRECATION: open-turo/actions-release/release-notes-preview@v1 has been deprecated.  Please use open-turo/actions-release/lint-release-notes@v3."
     - uses: actions/checkout@v3
+      if: inputs.checkout-repo
       with:
         fetch-depth: 0
     - name: Setup tools
@@ -62,14 +64,12 @@ runs:
         comment_id: ${{ steps.fc-release-notes.outputs.comment-id }}
         token: ${{ inputs.github-token }}
     - name: Comment release notes preview
+      id: release-notes-preview-comment
       uses: peter-evans/create-or-update-comment@v1
       if: steps.release-notes-preview.outputs.new-release-notes != '' && steps.find-pull-request.outputs.number != ''
       with:
         issue-number: ${{ steps.find-pull-request.outputs.number }}
         body: |
-          # DEPRECATION:
-          This action has been deprecated.  Please update to use `open-turo/actions-release/lint-release-notes@v1`.
-
           ## Release notes preview
           Below is a preview of the release notes if your PR gets merged.
 
@@ -107,10 +107,14 @@ runs:
         token: ${{ inputs.github-token }}
     - name: "Check File Existence"
       id: breaking-changes-file
+      if: inputs.enforce-breaking-changes-docs == 'true' && steps.find-pull-request.outputs.number != ''
       shell: bash
       run: |
+        echo "Checking for breaking changes file"
         set -e
         breaking_changes_file_missing=false
+        breaking_changes_file_default_content=false
+        breaking_changes_file_exists=false
         if [ "${{ steps.release-notes-preview.outputs.new-release-published }}" = "true" ]; then
           echo "new release published"
           if [ "${{ steps.release-notes-preview.outputs.new-release-type }}" = "major" ]; then
@@ -119,16 +123,30 @@ runs:
             # Check if the file exists
             if [ -e "$file_path" ]; then
               echo "breaking change doc $file_path exists."
+              expected_contents="Elaborate and add context to help the developer understand the changes"
+
+              breaking_changes_file_exists=true
+              if grep -Fq "$expected_contents" "$file_path"; then
+                echo "The file $file_path contains the default contents."
+                breaking_changes_file_default_content=true
+              fi
             else
               echo "breaking change doc $file_path does not exist."
               breaking_changes_file_missing=true
             fi
           fi
         fi
+        echo "Output: "
+        echo "   required=${breaking_changes_file_missing}"
+        echo "   default_content=${breaking_changes_file_default_content}"
+        echo "   exists=${breaking_changes_file_exists}"
         echo "required=${breaking_changes_file_missing}" >> $GITHUB_OUTPUT
+        echo "default_content=${breaking_changes_file_default_content}" >> $GITHUB_OUTPUT
+        echo "exists=${breaking_changes_file_exists}" >> $GITHUB_OUTPUT
+
     - name: Comment missing breaking changes doc
       uses: peter-evans/create-or-update-comment@v1
-      if: steps.breaking-changes-file.outputs.required && inputs.enforce-breaking-changes-docs && steps.find-pull-request.outputs.number != ''
+      if: steps.breaking-changes-file.outputs.required == 'true'
       with:
         issue-number: ${{ steps.find-pull-request.outputs.number }}
         body: |
@@ -143,15 +161,15 @@ runs:
           cat <<EOF > docs/breaking-changes/v${{ steps.release-notes-preview.outputs.new-release-major-version }}.md
           # Breaking changes in v${{ steps.release-notes-preview.outputs.new-release-major-version }}
 
-          [//]: # "Brief description of current major version release scope"
+          [//]: # "Brief description of current major version release scope. (remove comment after updating)"
 
           ## Description of changes
 
-          [//]: # "Elaborate and add context to help the developer understand the changes."
+          [//]: # "Elaborate and add context to help the developer understand the changes. (remove comment after updating)"
 
           ## Upgrade instructions
 
-          [//]: # "Required and suggested prerequisites, example code, etc."
+          [//]: # "Required and suggested prerequisites, example code, etc. (remove comment after updating)"
 
           EOF
           ```
@@ -159,8 +177,45 @@ runs:
 
           ---
           <!-- breaking changes comment -->
+    - name: Comment missing breaking changes doc
+      uses: peter-evans/create-or-update-comment@v1
+      if: steps.breaking-changes-file.outputs.default_content == 'true'
+      with:
+        issue-number: ${{ steps.find-pull-request.outputs.number }}
+        body: |
+          ## Error: breaking changes documentation must be updated
+          This pull request contains breaking changes, `docs/breaking-changes/v${{ steps.release-notes-preview.outputs.new-release-major-version }}.md` contains the default content.
+
+          Please update the content and push changes.
+
+          ---
+          <!-- breaking changes comment -->
+
+    - name: Get breaking changes doc
+      uses: mathiasvr/command-output@v2.0.0
+      id: breaking-changes-file-contents
+      if: steps.breaking-changes-file.outputs.exists == 'true'
+      with:
+        run: cat docs/breaking-changes/v${{ steps.release-notes-preview.outputs.new-release-major-version }}.md
+
+    - name: Append breaking changes doc to release notes preview
+      uses: peter-evans/create-or-update-comment@v1
+      if: steps.breaking-changes-file.outputs.exists == 'true'
+      with:
+        comment-id: ${{ steps.release-notes-preview-comment.outputs.comment-id }}
+        body: |
+          ---
+          ## Breaking changes file `docs/breaking-changes/v${{ steps.release-notes-preview.outputs.new-release-major-version }}.md`
+          ${{ steps.breaking-changes-file-contents.outputs.stdout }}
+          ---
+
     - name: Fail if we are checking for the breaking changes doc and it is missing
-      if: steps.breaking-changes-file.outputs.required && inputs.enforce-breaking-changes-docs
+      if: steps.breaking-changes-file.outputs.required == 'true'
       shell: bash
       run: |
-        echo "::error::Breaking changes document is missing. Expected: ``docs/breaking-changes/v${{ steps.release-notes-preview.outputs.new-release-major-version }}.md``" && exit 1
+        echo "::error::Breaking changes document is missing. Expected: 'docs/breaking-changes/v${{ steps.release-notes-preview.outputs.new-release-major-version }}.md'" && exit 1
+    - name: Fail if we are checking for the breaking changes doc and it has default content
+      if: steps.breaking-changes-file.outputs.default_content == 'true'
+      shell: bash
+      run: |
+        echo "::error::Breaking changes document has default content." && exit 1

--- a/release-notes-preview/README.md
+++ b/release-notes-preview/README.md
@@ -1,51 +1,5 @@
-# GitHub Action Release Notes Preview
+# DEPRECATED!!!! GitHub Action Release Notes Preview
 
 ## Description
 
-Github action that generates release notes using semantic-release and posts them as a comment in a pull request with the changes that would be included in the next version of the codebase if the pull request is merged.
-
-## Configuration
-
-### Step1: Set any [Semantic Release Configuration](https://github.com/semantic-release/semantic-release/blob/master/docs/usage/configuration.md#configuration) in your repository.
-
-### Step2: [Add Secrets](https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets) in your repository for the [Semantic Release Authentication](https://github.com/semantic-release/semantic-release/blob/master/docs/usage/ci-configuration.md#authentication) Environment Variables.
-
-### Step3: Add a [Workflow File](https://help.github.com/en/articles/workflow-syntax-for-github-actions) to your repository to create custom automated processes.
-
-## Usage
-
-```yaml
-name: Release notes preview
-
-on:
-  # It's import that this runs on the push event, as semantic release will not run on pull_request events
-  push:
-
-jobs:
-  release-notes:
-    name: Release notes preview
-    steps:
-      - uses: open-turo/actions-release/release-notes-preview@v1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-```
-
-## Inputs
-
-| parameter        | description                                                                                                                                                               | required | default                                   |
-| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ----------------------------------------- |
-| extra-plugins    | Extra plugins for pre-install. You can also specify specifying version range for the extra plugins if you prefer. Defaults to install @open-turo/semantic-release-config. | `false`  | @open-turo/semantic-release-config@^1.4.0 |
-| github-token     | GitHub token that can checkout the repository as well as create tags/releases against it. e.g. 'secrets.GITHUB_TOKEN'                                                     | `true`   |                                           |
-| semantic-version | Specify what version of semantic release to use                                                                                                                           | `false`  |                                           |
-
-## Outputs
-
-N/A
-
-## Runs
-
-This action is an `composite` action.
-
-## Notes
-
-- By default, this action will perform actions/checkout as its first step.
+This has been deprecated and will be removed in the future. Please use `open-turo/actions-release/lint-release-notes@v3`.


### PR DESCRIPTION
**Description**

* This adds a new `lint-release-notes` action that ensures that breaking change docs have been created and provides a preview of the release notes.
* DEPRECATED: action `actions-release/release-notes-preview`



🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
