### PR TITLE
feat: allow for overriding of the github env variables when running

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,3 +27,10 @@ repos:
     rev: v1.6.25
     hooks:
       - id: actionlint
+  - repo: local
+    hooks:
+      - id: update-action-readme
+        name: update-action-readme
+        entry: ./script/update-action-readme
+        language: script
+        files: '.*/action\.yaml$'

--- a/README.md
+++ b/README.md
@@ -38,3 +38,14 @@ this repository as needed.
 ## Contributions
 
 Please see [here](https://github.com/open-turo/contributions) for guidelines on how to contribute to this project.
+
+## Development
+
+### Documentation
+
+We are using [`action-docs`](https://github.com/npalm/action-docs) to keep our action documentation up to date. This is
+handled by a script that uses `npx` to run action-lint. To update documentation manually, run:
+
+```shell
+pre-commit run -a update-action-readme
+```

--- a/lint-release-notes/README.md
+++ b/lint-release-notes/README.md
@@ -1,10 +1,14 @@
 # GitHub Action Lint Release Notes
 
+<!-- prettier-ignore-start -->
+<!-- action-docs-description -->
 ## Description
 
 Github action that lints release notes. It generates release notes using semantic-release and posts them as a comment in
 a pull request with the changes that would be included in the next version of the codebase if the pull request is
 merged. It also will fail if there are breaking changes and no `v<major-version>.md` doc has been created.
+<!-- action-docs-description -->
+<!-- prettier-ignore-end -->
 
 ## Configuration
 
@@ -34,24 +38,33 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-## Inputs
-
-| parameter                     | description                                                                                                                                                               | required | default                                   |
-| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ----------------------------------------- |
-| checkout-repo                 | Perform checkout as first step of action                                                                                                                                  | `false`  | true                                      |
-| enforce-breaking-changes-docs | Ensure that an appropriate `v<major-version>.md` doc has been created if there are breaking changes in the PR. Fail if required and missing.                              | `false`  | `true`                                    |
-| extra-plugins                 | Extra plugins for pre-install. You can also specify specifying version range for the extra plugins if you prefer. Defaults to install @open-turo/semantic-release-config. | `false`  | @open-turo/semantic-release-config@^1.4.0 |
-| github-token                  | GitHub token that can checkout the repository as well as create tags/releases against it. e.g. 'secrets.GITHUB_TOKEN'                                                     | `true`   |                                           |
-| semantic-version              | Specify what version of semantic release to use                                                                                                                           | `false`  |                                           |
-
-## Outputs
-
-N/A
-
-## Runs
-
-This action is an `composite` action.
-
 ## Notes
 
 - By default, this action will perform actions/checkout as its first step.
+
+<!-- prettier-ignore-start -->
+<!-- action-docs-inputs -->
+## Inputs
+
+| parameter | description | required | default |
+| --- | --- | --- | --- |
+| checkout-repo | Perform checkout as first step of action | `false` | true |
+| github-token | GitHub token that can checkout the repository as well as create tags/releases against it. e.g. 'secrets.GITHUB_TOKEN' | `true` | ${{ github.token }} |
+| enforce-breaking-changes-docs | Ensure that an appropriate `v<major-version>.md` doc has been created if there are breaking changes in the PR. | `false` | true |
+| extra-plugins | Extra plugins for pre-install. You can also specify specifying version range for the extra plugins if you prefer.  Defaults to install @open-turo/semantic-release-config. | `false` | @open-turo/semantic-release-config  |
+| semantic-version | Specify what version of semantic release to use | `false` |  |
+<!-- action-docs-inputs -->
+
+<!-- action-docs-outputs -->
+
+<!-- action-docs-outputs -->
+
+<!-- action-docs-runs -->
+## Runs
+
+This action is a `composite` action.
+<!-- action-docs-runs -->
+
+<!-- action-docs-usage  -->
+<!-- action-docs-usage -->
+<!-- prettier-ignore-end -->

--- a/lint-release-notes/action.yaml
+++ b/lint-release-notes/action.yaml
@@ -1,5 +1,8 @@
 name: GitHub Action Release Notes Preview
-description: GitHub Action that publishes a new release.
+description: |-
+  Github action that lints release notes. It generates release notes using semantic-release and posts them as a comment in
+  a pull request with the changes that would be included in the next version of the codebase if the pull request is
+  merged. It also will fail if there are breaking changes and no `v<major-version>.md` doc has been created.
 inputs:
   checkout-repo:
     required: false

--- a/script/update-action-readme
+++ b/script/update-action-readme
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -e
+
+for i in $*; do
+  # ignore if the file does not end with /action.yaml
+  if [[ "$i" != *"/action.yaml" ]]; then
+    echo "skipping: ${i}"
+    continue
+  fi
+  readme_file=$(dirname "$i")/README.md
+  echo "npx action-docs --no-banner -a "${i}" --update-readme "${readme_file}""
+  npx action-docs --no-banner -a "${i}" --update-readme "${readme_file}"
+done

--- a/semantic-release/README.md
+++ b/semantic-release/README.md
@@ -1,8 +1,12 @@
 # GitHub Action Semantic Release
 
+<!-- prettier-ignore-start -->
+<!-- action-docs-description -->
 ## Description
 
 GitHub Action for Semantic Release
+<!-- action-docs-description -->
+<!-- prettier-ignore-end -->
 
 ## Configuration
 
@@ -32,35 +36,43 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
+<!-- prettier-ignore-start -->
+<!-- action-docs-inputs -->
 ## Inputs
 
-| parameter        | description                                                                                                                                                               | required | default                                   |
-| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ----------------------------------------- |
-| branches         | Override the branches where semantic release runs on. Accepts string or JSON object.                                                                                      | `false`  |                                           |
-| ci               | Set to false to skip Continuous Integration environment verifications                                                                                                     | `false`  |                                           |
-| dry-run          | Whether to run semantic release in `dry-run` mode. It will override the dryRun attribute in your configuration file                                                       | `false`  |                                           |
-| extra-plugins    | Extra plugins for pre-install. You can also specify specifying version range for the extra plugins if you prefer. Defaults to install @open-turo/semantic-release-config. | `false`  | @open-turo/semantic-release-config@^1.4.0 |
-| github-token     | GitHub token that can checkout the repository as well as create tags/releases against it. e.g. 'secrets.GITHUB_TOKEN'                                                     | `true`   |                                           |
-| semantic-version | Specify what version of semantic release to use                                                                                                                           | `false`  |                                           |
+| parameter | description | required | default |
+| --- | --- | --- | --- |
+| github-token | GitHub token that can checkout the repository as well as create tags/releases against it. e.g. 'secrets.GITHUB_TOKEN' | `true` | ${{ github.token }} |
+| branches | Override the branches where semantic release runs on. Accepts a string or a JSON object. | `false` |  |
+| ci | Set to false to skip Continuous Integration environment verifications | `false` |  |
+| dry-run | Whether to run semantic release in `dry-run` mode. It will override the dryRun attribute in your configuration file | `false` |  |
+| extra-plugins | Extra plugins for pre-install. You can also specify specifying version range for the extra plugins if you prefer. | `false` |  |
+| semantic-version | Specify what version of semantic release to use | `false` |  |
+| override-github-ref-name | Allow for override of github ref-name for running pull and repository dispatch triggered events | `false` |  |
+<!-- action-docs-inputs -->
 
+<!-- action-docs-outputs -->
 ## Outputs
 
-| parameter                  | description                                                                                                      |
-| -------------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| new-release-published      | Whether a new release was published                                                                              |
-| new-release-notes          | The release notes for the new release if any                                                                     |
-| new-release-version        | Version of the new release                                                                                       |
-| new-release-major-version  | Major version of the new release                                                                                 |
-| new-release-minor-version  | Minor version of the new release                                                                                 |
-| new-release-patch-version  | Patch version of the new release                                                                                 |
-| new-release-type           | Type of the new release: 'prerelease' \| 'prepatch' \| 'patch' \| 'preminor' \| 'minor' \| 'premajor' \| 'major' |
-| last-release-version       | Version of the last release                                                                                      |
-| last-release-major-version | Major version of the last release                                                                                |
+| parameter | description |
+| --- | --- |
+| new-release-published | Whether a new release was published |
+| new-release-notes | The release notes for the new release if any |
+| new-release-version | Version of the new release |
+| new-release-major-version | Major version of the new release |
+| new-release-minor-version | Minor version of the new release |
+| new-release-patch-version | Patch version of the new release |
+| new-release-type | Type of the new release: 'prerelease' | 'prepatch' | 'patch' | 'preminor' | 'minor' | 'premajor' | 'major' |
+| last-release-version | Version of the last release |
+| last-release-major-version | Major version of the last release |
+<!-- action-docs-outputs -->
 
+<!-- action-docs-runs -->
 ## Runs
 
-This action is an `composite` action.
+This action is a `composite` action.
+<!-- action-docs-runs -->
 
-## Notes
-
-- By default, this action will perform actions/checkout as its first step.
+<!-- action-docs-usage  -->
+<!-- action-docs-usage -->
+<!-- prettier-ignore-end -->

--- a/semantic-release/action.yaml
+++ b/semantic-release/action.yaml
@@ -24,6 +24,9 @@ inputs:
   semantic-version:
     required: false
     description: "Specify what version of semantic release to use"
+  override-github-ref-name:
+    required: false
+    description: "Allow for override of github ref-name for running pull and repository dispatch triggered events"
 outputs:
   new-release-published:
     description: "Whether a new release was published"
@@ -62,7 +65,27 @@ runs:
         node-version: "18"
     - name: Semantic-release
       id: semantic-release
-      run: node ${{ github.action_path }}/dist/index.js
+      run: |
+        if [[ ! -z "${{ inputs.override-github-ref-name }}" ]]; then
+
+          # if the override-github-ref-name is main or master, error
+          if [[ "${{ inputs.override-github-ref-name }}" == "main" || "${{ inputs.override-github-ref-name }}" == "master" ]]; then
+            echo "::error::Cannot override to main or master branch"
+            exit 1
+          fi
+          echo "::notice::Overriding github ref to ${{ github.ref }}"
+          export GITHUB_REF=refs/heads/${{ inputs.override-github-ref-name }}
+          export GITHUB_REF_NAME=${{ inputs.override-github-ref-name }}
+          export GITHUB_SHA=$(git rev-parse HEAD)
+          export GITHUB_REF_TYPE=branch
+          export GITHUB_REF_PROTECTED="false"
+        fi
+
+        echo "::group::bash environment"
+        set
+        echo "::endgroup::"
+
+        node ${{ github.action_path }}/dist/index.js
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}


### PR DESCRIPTION

**Description**

We need to be able to override the GitHub environment variables to allow for preview releases to run
on pull requests and through repository dispatch trigger events.



**Changes**

* feat: allow for overriding of the github env variables when running

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
