### PR TITLE
ci: remove pinned semantic-release-config version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           extra-plugins: |
-            @open-turo/semantic-release-config@4.0.3
+            @open-turo/semantic-release-config
   lint:
     name: Lint
     runs-on: ubuntu-latest
@@ -25,7 +25,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           semantic-release-extra-plugins: |
-            @open-turo/semantic-release-config@4.0.3
+            @open-turo/semantic-release-config
   test:
     name: Test
     runs-on: ubuntu-latest
@@ -40,4 +40,4 @@ jobs:
           override-github-ref-name: ${{ github.event.pull_request.head.ref }}
           dry-run: true
           extra-plugins: |
-            @open-turo/semantic-release-config@4.0.3
+            @open-turo/semantic-release-config

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,4 +30,4 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           extra-plugins: |
-            @open-turo/semantic-release-config@4.0.3
+            @open-turo/semantic-release-config


### PR DESCRIPTION

**Description**

We no longer need to pin the version. Moving forward we still have to come up with a way to have major updates of `semantic-release-config`



**Changes**

* ci: remove pinned semantic-release-config version

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
