### PR TITLE
fix(semantic-release): pin open-turo semantic-release-config

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,19 +4,6 @@ on:
   pull_request: {}
 
 jobs:
-  release-notes:
-    name: Release notes preview
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: ./lint-release-notes
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          extra-plugins: |
-            @open-turo/semantic-release-config
   lint:
     name: Lint
     runs-on: ubuntu-latest
@@ -25,7 +12,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           semantic-release-extra-plugins: |
-            @open-turo/semantic-release-config
+            @open-turo/semantic-release-config@6.1.2
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,4 +30,4 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           extra-plugins: |
-            @open-turo/semantic-release-config@6.1.2
+            @open-turo/semantic-release-config

--- a/semantic-release/src/index.ts
+++ b/semantic-release/src/index.ts
@@ -40,10 +40,18 @@ interface Inputs {
  */
 async function runNpmInstall(packages: string[]) {
   info(`Installing packages in ${path.resolve(__dirname, "..")}`);
+  // Hotfix for v4 of this action. There was a major release of @open-turo/semantic-release-config that breaks this action
+  // If v4 of this action is asking to install that module, pin it to the latest version
+  const actualPackages = packages.map((package_) => {
+    if (package_.includes("@open-turo/semantic-release-config")) {
+      return "@open-turo/semantic-release-config@6.1.2";
+    }
+    return package_;
+  });
   const silentFlag = process.env.RUNNER_DEBUG === "1" ? "" : "--silent";
   const data = await getExecOutput(
     "npm",
-    ["install", ...packages, "--no-audit", silentFlag],
+    ["install", ...actualPackages, "--no-audit", silentFlag],
     {
       cwd: path.resolve(__dirname, ".."),
     },

--- a/semantic-release/test/index.test.ts
+++ b/semantic-release/test/index.test.ts
@@ -264,6 +264,26 @@ describe("semantic-release", () => {
     `);
   });
 
+  test("pins @open-turo/semantic-release-config if asked as extra plugin", async () => {
+    process.env.SEMANTIC_ACTION_EXTRA_PLUGINS =
+      "@open-turo/semantic-release-config";
+    mockNpmInstall();
+    mockRelease({ nextRelease: undefined });
+    await callAction();
+    expect(getExecOutputMock).toHaveBeenCalledTimes(1);
+    const [cmd, arguments_] = getExecOutputMock.mock.calls[0];
+    expect(cmd).toMatchInlineSnapshot(`"npm"`);
+    expect(arguments_).toMatchInlineSnapshot(`
+      [
+        "install",
+        "semantic-release",
+        "@open-turo/semantic-release-config@6.1.2",
+        "--no-audit",
+        "--silent",
+      ]
+    `);
+  });
+
   test("propagates npm install errors", async () => {
     mockNpmInstall({
       exitCode: 1,


### PR DESCRIPTION
**Description**

There was a major release of `@open-turo/semantic-release-config`. Many of our `actions-<lang>` pass that config as extra plugin without pinning the version.

As a super hot fix, we pin the version here to the lastest working version with the semantic-release version this action uses (22).

As next steps, we should:

* Find a way for renovatebot to discover the pinned versions in the actions (we need to tweak the renovate-config repo)
* Release a major version of this action that supports the new semantic release version and allows releases to work again
* Pin the major version of semantic-release-config in all the `actions-<lang>` repos

As an alternative we could make that config a default in this repo, so it is easier to update. Since this action is mostly used for open-turo / turo configs it should be ok.

If CI passes in this branch, it probably means the fix works.

**Changes**

* fix(semantic-release): pin open-turo semantic-release-config

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
