### PR TITLE
fix: avoid double-wrapping text-detector in a comment

### DIFF
--- a/lint-release-notes/action.yaml
+++ b/lint-release-notes/action.yaml
@@ -75,7 +75,7 @@ runs:
       with:
         github-token: ${{ inputs.github-token }}
         workflow: ADD
-        text-detector: "<!-- release notes preview comment -->"
+        text-detector: "release notes preview comment"
         edit-mode: replace
         comment: |
           ## Release notes preview
@@ -92,7 +92,7 @@ runs:
       with:
         github-token: ${{ inputs.github-token }}
         workflow: ADD
-        text-detector: "<!-- release notes preview comment -->"
+        text-detector: "release notes preview comment"
         edit-mode: replace
         comment: |
           <!-- release notes preview comment -->
@@ -209,7 +209,7 @@ runs:
       with:
         github-token: ${{ inputs.github-token }}
         workflow: ADD
-        text-detector: "<!-- release notes preview comment -->"
+        text-detector: "release notes preview comment"
         edit-mode: append
         comment: |
           ---


### PR DESCRIPTION

**Description**

We are double-wrapping the text-detector in comment format. This fixes it by removing the comment wrappers from the text-detector.



**Changes**

* fix: avoid double-wrapping text-detector in a comment

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
