### PR TITLE
chore: unpin release notes version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
     rev: v3.1.0
     hooks:
       - id: prettier
-        additional_dependencies: ["prettier@3.5.1"]
+        stages: [commit]
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
     rev: v9.22.0
     hooks:

--- a/lint-release-notes/action.yaml
+++ b/lint-release-notes/action.yaml
@@ -20,7 +20,7 @@ inputs:
     required: false
     description: Extra plugins for pre-install. You can also specify specifying version range for the extra plugins if you prefer.  Defaults to install @open-turo/semantic-release-config.
     default: |
-      @open-turo/semantic-release-config@6.1.2
+      @open-turo/semantic-release-config
   semantic-version:
     required: false
     description: Specify what version of semantic release to use


### PR DESCRIPTION

**Description**

Unpins release notes pinned here, https://github.com/open-turo/actions-release/commit/2c4499c6d1822ec351297014804dab7507cf52f5
Release was already done.

Also updating pre-commit-config, renovate seems to have broken it.



**Changes**

* chore: unpin release notes version

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
