### PR TITLE
fix(lint-release-notes): override breaking changes doc

### DIFF
--- a/lint-release-notes/action.yaml
+++ b/lint-release-notes/action.yaml
@@ -213,7 +213,8 @@ runs:
         github-token: ${{ inputs.github-token }}
         workflow: ADD
         text-detector: "release notes preview comment"
-        edit-mode: append
+        edit-mode: replace
+        comment-author: "github-actions[bot]"
         comment: |
           ---
           ## Breaking changes file `docs/breaking-changes/v${{ steps.release-notes-preview.outputs.new-release-major-version }}.md`


### PR DESCRIPTION
**Summary**

<!-- fotingo:start summary -->
fix(lint-release-notes): override breaking changes doc
<!-- fotingo:end summary -->

**Description**

<!-- fotingo:start description -->
Every push in a PR that has breaking changes is creating a lot of noise, since a new comment gets added with the breaking changes docs. This PR updates that so the same comment is edited instead.
<!-- fotingo:end description -->

<!-- fotingo:start fixed-issues -->
<!-- fotingo:end fixed-issues -->

<!-- fotingo:start stacked-prs -->
<!-- fotingo:end stacked-prs -->

**Changes**

<!-- fotingo:start changes -->
* fix(lint-release-notes): override breaking changes doc (+2/-1)
<!-- fotingo:end changes -->

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
