### PR TITLE
feat(lint-release-notes): detect orphan breaking changes docs

### DIFF
--- a/lint-release-notes/action.yaml
+++ b/lint-release-notes/action.yaml
@@ -172,7 +172,6 @@ runs:
         workflow: ADD
         text-detector: "<!-- orphan breaking changes comment -->"
         edit-mode: replace
-        comment-author: "github-actions[bot]"
         comment: |
           ## Error: breaking changes doc without matching commit marker
 
@@ -193,6 +192,7 @@ runs:
 
           ---
           <!-- orphan breaking changes comment -->
+        comment-author: "github-actions[bot]"
 
     - name: Fail if orphan breaking changes doc
       if: steps.orphan-breaking-changes-doc.outputs.orphan == 'true'

--- a/lint-release-notes/action.yaml
+++ b/lint-release-notes/action.yaml
@@ -191,12 +191,6 @@ runs:
           <!-- orphan breaking changes comment -->
         comment-author: "github-actions[bot]"
 
-    - name: Fail if orphan breaking changes doc
-      if: steps.orphan-breaking-changes-doc.outputs.orphan == 'true'
-      shell: bash
-      run: |
-        echo "::error::Breaking changes doc was added but no BREAKING CHANGE commit marker found. semantic-release will not produce a major version bump." && exit 1
-
     - name: Comment missing breaking changes doc
       uses: open-turo/action-conditional-pr-comment@v1
       if: steps.breaking-changes-file.outputs.required == 'true'
@@ -274,6 +268,11 @@ runs:
           ${{ steps.breaking-changes-file-contents.outputs.stdout }}
           ---
 
+    - name: Fail if orphan breaking changes doc
+      if: steps.orphan-breaking-changes-doc.outputs.orphan == 'true'
+      shell: bash
+      run: |
+        echo "::error::Breaking changes doc was added but no BREAKING CHANGE commit marker found. semantic-release will not produce a major version bump." && exit 1
     - name: Fail if we are checking for the breaking changes doc and it is missing
       if: steps.breaking-changes-file.outputs.required == 'true'
       shell: bash

--- a/lint-release-notes/action.yaml
+++ b/lint-release-notes/action.yaml
@@ -2,7 +2,8 @@ name: GitHub Action Release Notes Preview
 description: |-
   Github action that lints release notes. It generates release notes using semantic-release and posts them as a comment in
   a pull request with the changes that would be included in the next version of the codebase if the pull request is
-  merged. It also will fail if there are breaking changes and no `v<major-version>.md` doc has been created.
+  merged. It also will fail if there are breaking changes and no `v<major-version>.md` doc has been created, or if a
+  breaking changes doc is added without a matching BREAKING CHANGE commit marker.
 inputs:
   checkout-repo:
     required: false
@@ -143,6 +144,61 @@ runs:
         echo "required=${breaking_changes_file_missing}" >> $GITHUB_OUTPUT
         echo "default_content=${breaking_changes_file_default_content}" >> $GITHUB_OUTPUT
         echo "exists=${breaking_changes_file_exists}" >> $GITHUB_OUTPUT
+
+    - name: Check for orphan breaking changes doc
+      id: orphan-breaking-changes-doc
+      if: inputs.enforce-breaking-changes-docs == 'true' && github.event.pull_request.number != ''
+      shell: bash
+      run: |
+        new_bc_docs=$(git diff --name-only --diff-filter=A "origin/${{ github.event.pull_request.base.ref }}...HEAD" -- docs/breaking-changes/)
+        if [ -n "$new_bc_docs" ]; then
+          release_type="${{ steps.release-notes-preview.outputs.new-release-type }}"
+          if [ "$release_type" != "major" ]; then
+            echo "orphan=true" >> $GITHUB_OUTPUT
+            echo "files=$new_bc_docs" >> $GITHUB_OUTPUT
+            echo "::error::Breaking change doc added ($new_bc_docs) but semantic-release does not detect a major version bump (detected: ${release_type:-none})."
+          else
+            echo "orphan=false" >> $GITHUB_OUTPUT
+          fi
+        else
+          echo "orphan=false" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Comment orphan breaking changes doc
+      uses: open-turo/action-conditional-pr-comment@v1
+      if: steps.orphan-breaking-changes-doc.outputs.orphan == 'true'
+      with:
+        github-token: ${{ inputs.github-token }}
+        workflow: ADD
+        text-detector: "<!-- orphan breaking changes comment -->"
+        edit-mode: replace
+        comment-author: "github-actions[bot]"
+        comment: |
+          ## Error: breaking changes doc without matching commit marker
+
+          A breaking changes documentation file was added:
+          ```
+          ${{ steps.orphan-breaking-changes-doc.outputs.files }}
+          ```
+
+          But none of the commits in this PR will trigger a **major** version bump.
+          semantic-release will produce a minor or patch release, and the doc filename will not match the actual release version.
+
+          **Fix:** add a `BREAKING CHANGE:` footer to the relevant commit message:
+          ```
+          fix: your commit subject
+
+          BREAKING CHANGE: description of what breaks for consumers
+          ```
+
+          ---
+          <!-- orphan breaking changes comment -->
+
+    - name: Fail if orphan breaking changes doc
+      if: steps.orphan-breaking-changes-doc.outputs.orphan == 'true'
+      shell: bash
+      run: |
+        echo "::error::Breaking changes doc was added but no BREAKING CHANGE commit marker found. semantic-release will not produce a major version bump." && exit 1
 
     - name: Comment missing breaking changes doc
       uses: open-turo/action-conditional-pr-comment@v1

--- a/lint-release-notes/action.yaml
+++ b/lint-release-notes/action.yaml
@@ -156,12 +156,10 @@ runs:
             echo "orphan=true" >> $GITHUB_OUTPUT
             echo "files=$new_bc_docs" >> $GITHUB_OUTPUT
             echo "::error::Breaking change doc added ($new_bc_docs) but semantic-release does not detect a major version bump (detected: ${{ steps.release-notes-preview.outputs.new-release-type }})."
-          else
-            echo "orphan=false" >> $GITHUB_OUTPUT
+            exit 0
           fi
-        else
-          echo "orphan=false" >> $GITHUB_OUTPUT
         fi
+        echo "orphan=false" >> $GITHUB_OUTPUT
 
     - name: Comment orphan breaking changes doc
       uses: open-turo/action-conditional-pr-comment@v1

--- a/lint-release-notes/action.yaml
+++ b/lint-release-notes/action.yaml
@@ -152,11 +152,10 @@ runs:
       run: |
         new_bc_docs=$(git diff --name-only --diff-filter=A "origin/${{ github.event.pull_request.base.ref }}...HEAD" -- docs/breaking-changes/)
         if [ -n "$new_bc_docs" ]; then
-          release_type="${{ steps.release-notes-preview.outputs.new-release-type }}"
-          if [ "$release_type" != "major" ]; then
+          if [ "${{ steps.release-notes-preview.outputs.new-release-type }}" != "major" ]; then
             echo "orphan=true" >> $GITHUB_OUTPUT
             echo "files=$new_bc_docs" >> $GITHUB_OUTPUT
-            echo "::error::Breaking change doc added ($new_bc_docs) but semantic-release does not detect a major version bump (detected: ${release_type:-none})."
+            echo "::error::Breaking change doc added ($new_bc_docs) but semantic-release does not detect a major version bump (detected: ${{ steps.release-notes-preview.outputs.new-release-type }})."
           else
             echo "orphan=false" >> $GITHUB_OUTPUT
           fi


### PR DESCRIPTION
## Description

Adds detection for "orphan" breaking changes documentation files — cases where a `docs/breaking-changes/v<major>.md` file is added in a PR but no commit contains a `BREAKING CHANGE:` footer that would actually trigger a major version bump via semantic-release.

Without this check, a contributor could add a breaking changes doc assuming it will match the next release version, but semantic-release would only produce a minor or patch release, leaving the doc filename mismatched.

## Changes

- **New step: `Check for orphan breaking changes doc`** — Compares newly added files under `docs/breaking-changes/` against the release type detected by semantic-release. If the release type is not `major`, the doc is flagged as orphan.
- **New step: `Comment orphan breaking changes doc`** — Posts (or updates) a PR comment explaining the issue and how to fix it (add a `BREAKING CHANGE:` commit footer).
- **New step: `Fail if orphan breaking changes doc`** — Fails the workflow with a clear error message when an orphan doc is detected.
- Updated the action description to reflect the new behavior.

## Testing

- Verified on a PR with a breaking changes doc but no `BREAKING CHANGE:` commit marker → workflow fails with the expected error and PR comment.
- Verified on a PR with both a breaking changes doc and a proper `BREAKING CHANGE:` commit → workflow passes normally.
- Verified on a PR with no breaking changes doc → no change in behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)