### PR TITLE
ci/npm-trusted-publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,6 +3,17 @@ name: Release
 on:
   push:
     branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: read
+  pull-requests: read
+  id-token: write
 
 jobs:
   lint:


### PR DESCRIPTION
**Summary**

<!-- fotingo:start summary -->
Add permissions block and concurrency for trusted publishing
<!-- fotingo:end summary -->

**Description**

<!-- fotingo:start description -->
Align the release workflow with the org-wide trusted publishing pattern:

- Add explicit `permissions` block with `id-token: write` for OIDC trusted publishing
- Add `concurrency` group to prevent simultaneous release runs
- Add `workflow_dispatch` for manual triggers
<!-- fotingo:end description -->

<!-- fotingo:start fixed-issues -->
<!-- fotingo:end fixed-issues -->

<!-- fotingo:start stacked-prs -->
<!-- fotingo:end stacked-prs -->

**Changes**

<!-- fotingo:start changes -->
* ci: add permissions block and concurrency for trusted publishing (+11/-0)
<!-- fotingo:end changes -->

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)